### PR TITLE
Fixed what appears to be a typing error

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ fetchJsonp('/users.jsonp', {
 
 ### Caveats
 
-You need to call `.then(function(respons) { return respons.json(); })` in order
+You need to call `.then(function(response) { return response.json(); })` in order
 to keep consistent with Fetch API.
 
 ## Browser Support


### PR DESCRIPTION
Added the last letter 'e' to the word response in the example under the Caveats section.