### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,6 @@ You can install with `npm`.
 npm install fetch-jsonp
 ```
 
-You'll also need a Promise polyfill for [old browsers](http://caniuse.com/#feat=promises).
-
-```
-npm install es6-promise
-```
-
 ## Usage
 
 The `fetch-jsonp` function supports any HTTP method. We'll focus on GET and POST


### PR DESCRIPTION
I'm a little confused by this line:

```
You'll also need a Promise polyfill for old browsers.

npm install es6-promise
```

es6-promise is a node dependency and is automatically brought in via `npm install`. Is this line even necessary?