### PR TITLE
Handle <script> error event

### DIFF
--- a/src/fetch-jsonp.js
+++ b/src/fetch-jsonp.js
@@ -60,6 +60,12 @@ function fetchJsonp(_url, options = {}) {
       jsonpScript.setAttribute('charset', options.charset);
     }
     jsonpScript.id = scriptId;
+    jsonpScript.onerror = () => {
+      reject(new Error(`JSONP request to ${_url} failed`));
+
+      clearFunction(callbackFunction);
+      removeScript(scriptId);
+    }
     document.getElementsByTagName('head')[0].appendChild(jsonpScript);
 
     timeoutId = setTimeout(() => {


### PR DESCRIPTION
Hi @camsong 

I come across a weird behaviour when the URL fails to load, `fetchJsonp` returned promise is still in a pending state. I have to wait for the timeout to happen, and eventually the promise will be rejected. 

We can save some time by adding an `error` listener on the `<script>` tag.
So, when a request fails, `fetchJsonp()` promise will be rejected right away.

Will also solve this issue: https://github.com/camsong/fetch-jsonp/issues/1