### PR TITLE
fix(bug fix): :bug:determine script node before remove it

### DIFF
--- a/src/fetch-jsonp.js
+++ b/src/fetch-jsonp.js
@@ -22,7 +22,9 @@ function clearFunction(functionName) {
 
 function removeScript(scriptId) {
   const script = document.getElementById(scriptId);
-  document.getElementsByTagName('head')[0].removeChild(script);
+  if (script) {
+    document.getElementsByTagName('head')[0].removeChild(script);
+  }
 }
 
 function fetchJsonp(_url, options = {}) {


### PR DESCRIPTION

i set `timeout` to `60000`, then requested an invalid url and got a 404 exception, the `Promise` caught it, but after a while (might be 60s later) i got another exception as you can see in the pics blow. 

maybe we should add `if (script)` condition  before excute `removeChild`

![image](https://user-images.githubusercontent.com/5194746/26961816-33ca1af2-4d14-11e7-9d87-cdacd24e4293.png)

![image](https://user-images.githubusercontent.com/5194746/26961408-eb82d3fe-4d10-11e7-92c9-a40574f937ba.png)
