### PR TITLE
Set values of options to be optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,8 +5,9 @@ declare namespace fetchJsonp {
     timeout?: number;
     jsonpCallback?: string;
     jsonpCallbackFunction?: string;
-    nonce: string;
-    referrerPolicy: ReferrerPolicy;
+    nonce?: string;
+    referrerPolicy?: ReferrerPolicy;
+    charset?: string;
   }
 
   interface Response {


### PR DESCRIPTION
I have set the `nonce` and `referrerPolicy` to be optional in the typing, correctly reflecting intended use.

I did also notice when I was giving the code a quick read through there was another option available that was completely missing from the typing for the `charset`, so I dropped that in as well.

fixes #66 