### PR TITLE
feat: allow applications to set crossorigin attribute

### DIFF
--- a/build/fetch-jsonp.js
+++ b/build/fetch-jsonp.js
@@ -84,6 +84,9 @@
       if (options.referrerPolicy) {
         jsonpScript.setAttribute('referrerPolicy', options.referrerPolicy);
       }
+      if (options.crossorigin) {
+        jsonpScript.setAttribute('crossorigin', 'true');
+      }
       jsonpScript.id = scriptId;
       document.getElementsByTagName('head')[0].appendChild(jsonpScript);
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ declare namespace fetchJsonp {
     jsonpCallback?: string;
     jsonpCallbackFunction?: string;
     nonce?: string;
+    crossorigin?: boolean;
     referrerPolicy?: ReferrerPolicy;
     charset?: string;
   }

--- a/src/fetch-jsonp.js
+++ b/src/fetch-jsonp.js
@@ -65,6 +65,9 @@ function fetchJsonp(_url, options = {}) {
     if (options.referrerPolicy) {
       jsonpScript.setAttribute('referrerPolicy', options.referrerPolicy);
     }
+    if (options.crossorigin) {
+      jsonpScript.setAttribute('crossorigin', 'true');
+    }
     jsonpScript.id = scriptId;
     document.getElementsByTagName('head')[0].appendChild(jsonpScript);
 


### PR DESCRIPTION
hi @camsong 

this PR will allow applications to set the `crossorigin` attribute on the script tag. This allows for more finegrained control over cross-origin resources especially when used together with https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy.

> A document can only load resources from the same origin, or resources explicitly marked as loadable from another origin. If a cross origin resource supports CORS, the [crossorigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) attribute or the [Cross-Origin-Resource-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy) header must be used to load it without being blocked by COEP.

The feature is backwards-compatible as it is disabled by default.