### PR TITLE
Switch "DT" symbol to "TS" on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "fetch-jsonp",
   "version": "1.3.0",
   "description": "Fetch JSONP like a boss using Fetch API",
-  "main": "build/fetch-jsonp.js",
+  "main": "./build/fetch-jsonp.js",
+  "types": "./index.d.ts",
   "scripts": {
     "prepublish": "npm run lint && npm run clean && npm run build",
     "build": "babel src/ --modules umd --out-dir build",


### PR DESCRIPTION
First of all, thanks for `fetch-jsonp`, useful library!

## What?

Add a [`"types"` field to `package.json`](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package), like Jest and other package including their own types.

## Why?

On [the npm page for `fetch-jsonp`](https://www.npmjs.com/package/fetch-jsonp), there is a "DT" symbol, indicating that the library has 3rd-party [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) types:

![Screenshot 2024-07-10 at 15 10 01](https://github.com/camsong/fetch-jsonp/assets/1935696/0444b29c-ea1d-4b97-b574-0c8745f44f43)


The "DT" symbol links to [`@types/fetch-jsonp`](https://www.npmjs.com/package/@types/fetch-jsonp), which has a deprecation notice:

```
This is a stub types definition. fetch-jsonp provides its own type definitions, so you do not need this installed.
```

![Screenshot 2024-07-10 at 15 14 01](https://github.com/camsong/fetch-jsonp/assets/1935696/8e809483-ecd4-4ea7-bc13-e5627dacef96)

npm should report the correct types source for the library, with the blue "TS" symbol as can be seen on [the npm page for `jest`](https://www.npmjs.com/package/jest):

![341327086-9f27ccc0-6f95-4409-99cc-64cade91d0a0](https://github.com/camsong/fetch-jsonp/assets/1935696/27c7f447-a61d-49f1-bcbc-545bf6ac5d15)

The `jest` package includes its own types and the npm page shows the "TS" symbol, even though the package [`@types/jest`](https://www.npmjs.com/package/@types/jest) also exists.

