### PR TITLE
Add fetchPriority support

### DIFF
--- a/build/fetch-jsonp.js
+++ b/build/fetch-jsonp.js
@@ -87,8 +87,9 @@
       if (options.crossorigin) {
         jsonpScript.setAttribute('crossorigin', 'true');
       }
-      if (['high', 'low', 'auto'].indexOf(options.fetchPriority) !== -1) {
-        jsonpScript.setAttribute('fetchPriority', options.fetchPriority);
+      var fp = options.fetchPriority;
+      if (fp === 'high' || fp === 'low' || fp === 'auto') {
+        jsonpScript.setAttribute('fetchPriority', fp);
       }
       jsonpScript.id = scriptId;
       document.getElementsByTagName('head')[0].appendChild(jsonpScript);

--- a/build/fetch-jsonp.js
+++ b/build/fetch-jsonp.js
@@ -87,6 +87,9 @@
       if (options.crossorigin) {
         jsonpScript.setAttribute('crossorigin', 'true');
       }
+      if (['high', 'low', 'auto'].indexOf(options.fetchPriority) !== -1) {
+        jsonpScript.setAttribute('fetchPriority', options.fetchPriority);
+      }
       jsonpScript.id = scriptId;
       document.getElementsByTagName('head')[0].appendChild(jsonpScript);
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ declare namespace fetchJsonp {
     crossorigin?: boolean;
     referrerPolicy?: ReferrerPolicy;
     charset?: string;
+    fetchPriority?: 'high' | 'low' | 'auto';
   }
 
   interface Response {

--- a/src/fetch-jsonp.js
+++ b/src/fetch-jsonp.js
@@ -68,8 +68,9 @@ function fetchJsonp(_url, options = {}) {
     if (options.crossorigin) {
       jsonpScript.setAttribute('crossorigin', 'true');
     }
-    if (['high', 'low', 'auto'].indexOf(options.fetchPriority) !== -1) {
-      jsonpScript.setAttribute('fetchPriority', options.fetchPriority);
+    const fp = options.fetchPriority;
+    if (fp === 'high' || fp === 'low' || fp === 'auto') {
+      jsonpScript.setAttribute('fetchPriority', fp);
     }
     jsonpScript.id = scriptId;
     document.getElementsByTagName('head')[0].appendChild(jsonpScript);

--- a/src/fetch-jsonp.js
+++ b/src/fetch-jsonp.js
@@ -68,6 +68,9 @@ function fetchJsonp(_url, options = {}) {
     if (options.crossorigin) {
       jsonpScript.setAttribute('crossorigin', 'true');
     }
+    if (['high', 'low', 'auto'].indexOf(options.fetchPriority) !== -1) {
+      jsonpScript.setAttribute('fetchPriority', options.fetchPriority);
+    }
     jsonpScript.id = scriptId;
     document.getElementsByTagName('head')[0].appendChild(jsonpScript);
 


### PR DESCRIPTION
resolved https://github.com/camsong/fetch-jsonp/issues/70

This change makes use of the fetchPriority attribute on <script> to control the request priority. The attribute is already widely supported in modern browsers (see [MDN](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Reference/Elements/script#fetchpriority)), and it has no adverse effect in browsers that do not support it.